### PR TITLE
use dirname(@__FILE__) instead of Pkg.dir

### DIFF
--- a/src/loading.jl
+++ b/src/loading.jl
@@ -1,5 +1,5 @@
 function datafile(filename)
-	joinpath(Pkg.dir("NamedColors"),"data", filename)
+	joinpath(dirname(@__FILE__),"..","data", filename)
 end
 
 """


### PR DESCRIPTION
this allows installing the package elsewhere
